### PR TITLE
Added some predicates to the interface.

### DIFF
--- a/prolog/mcintyre.pl
+++ b/prolog/mcintyre.pl
@@ -66,7 +66,11 @@ details.
   ~= /2,
   swap/2,
   msw/2,
-  set_sw/2
+  set_sw/2,
+  to_pair/2,
+  key/2,
+  y/2,
+  bin/5
   ]).
 :-meta_predicate s(:,-).
 :-meta_predicate mc_prob(:,-).


### PR DESCRIPTION
I have exported some predicates that are used by the [cplint-r](https://github.com/frnmst/cplint-r/blob/master/prolog/cplint_r.pl) library.

This avoids duplicating predicates in the cplint-r library itself. The only thing to do instead is:

    use_module(library(mcintyre)).
    use_module(library(pita)).