### PR TITLE
TEST: Load tests when using optimized arithmetic.

### DIFF
--- a/prolog/cplint_test/test.pl
+++ b/prolog/cplint_test/test.pl
@@ -1,4 +1,4 @@
-
+:- set_test_options([load(always)]).
 :- use_module(test_pita).
 :- use_module(test_mc).
 :- use_module(test_kbest).


### PR DESCRIPTION
Allows loading and running `library(cplint_test/test)` using (arithmetic) optimization (`-O`).  Doesn't help much (about 4%).  Using PGO optimized Prolog helps much more (~25%).