### PR TITLE
Fix pita.pl line 1745

### DIFF
--- a/prolog/pita.pl
+++ b/prolog/pita.pl
@@ -1742,7 +1742,7 @@ pita_expansion((Head :- Body), Clauses) :-
   ((Head:-Body) \= ((pita_expansion(_,_) ):- _ )),
   list2or(HeadListOr, Head),
   process_head(HeadListOr, HeadList),
-  HeadList=[_H:_],!,
+  HeadList=[_H:P|_],P =:= 1.0,!,
   list2and(BodyList, Body),
   process_body(BodyList,BDD,BDDAnd,[],_Vars,BodyList2,Env,M),
   append([onec(Env,BDD)],BodyList2,BodyList3),


### PR DESCRIPTION
For a probabilistic clause with a single head whose probability=1.0, such as "1.0::a :- b.", without depth-bound, it should be expanded by the pita_expansion clause at line 1739. However, due to the check "HeadList=[\_H:\_]" at line 1745 the resolution can go no further, because the HeadList returned by process_head/2 is [a:1.0,:0.0]. So eventually such rule will be treated by the pita_expansion at line 1779. The solution proposed is simply to replace the line 1745 by "HeadList=[\_H:P|\_],P =:= 1.0,!,".